### PR TITLE
Feature/37 end point to update public data of the organization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,19 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.modelmapper</groupId>
+			<artifactId>modelmapper</artifactId>
+			<version>2.4.4</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.openapitools</groupId>
+			<artifactId>jackson-databind-nullable</artifactId>
+			<version>0.2.1</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/alkemy/ong/config/MvcConfig.java
+++ b/src/main/java/com/alkemy/ong/config/MvcConfig.java
@@ -1,0 +1,18 @@
+package com.alkemy.ong.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class MvcConfig implements WebMvcConfigurer {
+    @Bean
+    public MessageSource messageSource() {
+        ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("locale/messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        return messageSource;
+    }
+}

--- a/src/main/java/com/alkemy/ong/controller/OrganizationController.java
+++ b/src/main/java/com/alkemy/ong/controller/OrganizationController.java
@@ -20,7 +20,7 @@ public class OrganizationController {
     private final IOrganizationService iOrganizationService;
 
     @PatchMapping("/public")
-    //@PreAuthorize("hasAnyRole('ROLE_ADMIN')")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
     public ResponseEntity<OrganizationResponse> updatePublicData(@Valid @RequestBody OrganizationRequest organization){
         return new ResponseEntity<OrganizationResponse>(iOrganizationService.updatePublicData(organization), HttpStatus.OK);
     }

--- a/src/main/java/com/alkemy/ong/controller/OrganizationController.java
+++ b/src/main/java/com/alkemy/ong/controller/OrganizationController.java
@@ -3,6 +3,7 @@ package com.alkemy.ong.controller;
 import com.alkemy.ong.dto.OrganizationRequest;
 import com.alkemy.ong.dto.OrganizationResponse;
 import com.alkemy.ong.model.Organization;
+import com.alkemy.ong.security.RoleEnum;
 import com.alkemy.ong.service.IOrganizationService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,10 +19,12 @@ import javax.validation.Valid;
 public class OrganizationController {
 
     private final IOrganizationService iOrganizationService;
+    private final String role_admin = RoleEnum.ADMIN.name();
 
     @PatchMapping("/public")
-    @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
+    @PreAuthorize("hasAnyRole(T(com.alkemy.ong.security.RoleEnum).ADMIN)")
     public ResponseEntity<OrganizationResponse> updatePublicData(@Valid @RequestBody OrganizationRequest organization){
         return new ResponseEntity<OrganizationResponse>(iOrganizationService.updatePublicData(organization), HttpStatus.OK);
     }
+
 }

--- a/src/main/java/com/alkemy/ong/controller/OrganizationController.java
+++ b/src/main/java/com/alkemy/ong/controller/OrganizationController.java
@@ -1,0 +1,27 @@
+package com.alkemy.ong.controller;
+
+import com.alkemy.ong.dto.OrganizationRequest;
+import com.alkemy.ong.dto.OrganizationResponse;
+import com.alkemy.ong.model.Organization;
+import com.alkemy.ong.service.IOrganizationService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("/organization")
+public class OrganizationController {
+
+    private final IOrganizationService iOrganizationService;
+
+    @PatchMapping("/public")
+    //@PreAuthorize("hasAnyRole('ROLE_ADMIN')")
+    public ResponseEntity<OrganizationResponse> updatePublicData(@Valid @RequestBody OrganizationRequest organization){
+        return new ResponseEntity<OrganizationResponse>(iOrganizationService.updatePublicData(organization), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/alkemy/ong/dto/OrganizationRequest.java
+++ b/src/main/java/com/alkemy/ong/dto/OrganizationRequest.java
@@ -1,0 +1,29 @@
+package com.alkemy.ong.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openapitools.jackson.nullable.JsonNullable;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@Setter
+@ToString
+public class OrganizationRequest {
+
+
+    private String name;
+    private String image;
+    private JsonNullable<String> address;
+    @Max(value = 9999999999999L, message = "Invalid phone number")
+    @Min(value = 0, message = "Invalid phone number")
+    private JsonNullable<Long> phone;
+    @Pattern(regexp=".+@.+\\.[a-z]+", message="Invalid email address")
+    private String email;
+    private String welcomeText;
+    private JsonNullable<String> aboutUsText;
+
+}

--- a/src/main/java/com/alkemy/ong/dto/OrganizationResponse.java
+++ b/src/main/java/com/alkemy/ong/dto/OrganizationResponse.java
@@ -1,0 +1,19 @@
+package com.alkemy.ong.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class OrganizationResponse {
+    private String name;
+    private String image;
+    private String address;
+    private Long phone;
+    private String email;
+    private String welcomeText;
+    private String aboutUsText;
+
+}

--- a/src/main/java/com/alkemy/ong/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/alkemy/ong/exception/ApiExceptionHandler.java
@@ -1,0 +1,59 @@
+package com.alkemy.ong.exception;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+	
+
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(Exception.class)
+	@ResponseBody
+	public ExceptionMessage retunrError(Exception e) {
+		return new ExceptionMessage(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage(), LocalDateTime.now());
+
+	}
+	
+	
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ExceptionHandler(NotFoundException.class)
+	@ResponseBody
+	public ExceptionMessage retunrErrorBadRequest(NotFoundException e) {
+		return new ExceptionMessage(HttpStatus.NOT_FOUND.value(), e.getMessage(), LocalDateTime.now());
+	}
+	
+	
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(IllegalArgumentException.class)
+	@ResponseBody
+	public ExceptionMessage retunrErrorIllegalArgument(IllegalArgumentException e) {
+		return new ExceptionMessage(HttpStatus.BAD_REQUEST.value(), e.getMessage(), LocalDateTime.now());
+	}
+	
+	
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	@ResponseBody
+	public ExceptionMessage retunrErrorMethodArgumentNotValid(MethodArgumentNotValidException e) {
+		Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+		return new ExceptionMessage(HttpStatus.BAD_REQUEST.value(),"bad request", LocalDateTime.now(), errors);
+	}
+	
+	
+}

--- a/src/main/java/com/alkemy/ong/exception/ExceptionMessage.java
+++ b/src/main/java/com/alkemy/ong/exception/ExceptionMessage.java
@@ -1,0 +1,33 @@
+package com.alkemy.ong.exception;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ExceptionMessage {
+
+	private int code;
+	private String message;
+	private LocalDateTime timestamp;
+	private Map<String, String> errors;
+	
+	
+	
+	public ExceptionMessage(int code, String message, LocalDateTime timestamp) {
+		this.code = code;
+		this.message = message;
+		this.timestamp = timestamp;
+	}
+
+	public ExceptionMessage(int code, String message, LocalDateTime timestamp, Map<String, String> errors) {
+		this.code = code;
+		this.message = message;
+		this.timestamp = timestamp;
+		this.errors = errors;
+	}
+	
+}

--- a/src/main/java/com/alkemy/ong/exception/NotFoundException.java
+++ b/src/main/java/com/alkemy/ong/exception/NotFoundException.java
@@ -1,5 +1,9 @@
 package com.alkemy.ong.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class NotFoundException extends RuntimeException{
     public NotFoundException(String s) {
         super(s);

--- a/src/main/java/com/alkemy/ong/exception/NotFoundException.java
+++ b/src/main/java/com/alkemy/ong/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.alkemy.ong.exception;
+
+public class NotFoundException extends RuntimeException{
+    public NotFoundException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/com/alkemy/ong/model/Slide.java
+++ b/src/main/java/com/alkemy/ong/model/Slide.java
@@ -13,6 +13,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
 import lombok.Data;
 
 

--- a/src/main/java/com/alkemy/ong/security/RoleEnum.java
+++ b/src/main/java/com/alkemy/ong/security/RoleEnum.java
@@ -1,5 +1,21 @@
 package com.alkemy.ong.security;
 
 public enum RoleEnum {
-    USER, ADMIN
+    ADMIN("ADMIN"),
+    USER("USER");
+
+    private final String name;
+    private static final String ROLE_ = "ROLE_";
+
+    RoleEnum(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRoleName() {
+        return ROLE_ + name;
+    }
 }

--- a/src/main/java/com/alkemy/ong/security/RoleEnum.java
+++ b/src/main/java/com/alkemy/ong/security/RoleEnum.java
@@ -1,0 +1,5 @@
+package com.alkemy.ong.security;
+
+public enum RoleEnum {
+    USER, ADMIN
+}

--- a/src/main/java/com/alkemy/ong/service/IOrganizationService.java
+++ b/src/main/java/com/alkemy/ong/service/IOrganizationService.java
@@ -1,0 +1,12 @@
+package com.alkemy.ong.service;
+
+
+import com.alkemy.ong.dto.OrganizationRequest;
+import com.alkemy.ong.dto.OrganizationResponse;
+import com.alkemy.ong.model.Organization;
+
+public interface IOrganizationService {
+
+    public OrganizationResponse updatePublicData(OrganizationRequest organization);
+
+}

--- a/src/main/java/com/alkemy/ong/service/impl/OrganizationServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/OrganizationServiceImpl.java
@@ -1,0 +1,79 @@
+package com.alkemy.ong.service.impl;
+
+import com.alkemy.ong.dto.OrganizationRequest;
+import com.alkemy.ong.dto.OrganizationResponse;
+import com.alkemy.ong.exception.NotFoundException;
+import com.alkemy.ong.model.Organization;
+import com.alkemy.ong.repository.OrganizationRepository;
+import com.alkemy.ong.service.IOrganizationService;
+import lombok.RequiredArgsConstructor;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+@Service
+@RequiredArgsConstructor
+public class OrganizationServiceImpl implements IOrganizationService {
+
+    private final OrganizationRepository organizationRepository;
+    private Boolean hasUpdate = Boolean.FALSE;
+
+    @Override
+    @Transactional
+    public OrganizationResponse updatePublicData(OrganizationRequest organizationRequest) {
+
+        final Long organizationId = 1L;//se considera que solo hay una organización
+        Organization organization = organizationRepository.findById(organizationId)
+                                                        .orElseThrow(()-> new NotFoundException(String.format("cannot find organization with id %s", organizationId)));
+
+        updateIfNotBlankAndNotEqual(organizationRequest.getName(), organization.getName(), organization::setName , "name");
+        updateIfNotBlankAndNotEqual(organizationRequest.getImage(), organization.getImage(), organization::setImage , "image");
+        updateIfNotBlankAndNotEqual(organizationRequest.getEmail(), organization.getEmail(), organization::setEmail , "email");
+        updateIfNotBlankAndNotEqual(organizationRequest.getWelcomeText(), organization.getWelcomeText(), organization::setWelcomeText , "welcome text");
+
+        updateIfNotEmptyAndNotEqual(organizationRequest.getPhone(), organization.getPhone(), organization::setPhone , "phone");
+        updateIfNotEmptyAndNotEqual(organizationRequest.getAddress(), organization.getAddress(), organization::setAddress , "address");
+        updateIfNotEmptyAndNotEqual(organizationRequest.getAboutUsText(), organization.getAboutUsText(), organization::setAboutUsText , "about us text");
+
+        if (hasUpdate){
+            organization.setDateUpdate(LocalDateTime.now());
+        }
+
+        return new OrganizationResponse(organization.getName()
+                                        ,organization.getImage()
+                                        ,organization.getAddress()
+                                        ,organization.getPhone()
+                                        ,organization.getEmail()
+                                        ,organization.getWelcomeText()
+                                        , organization.getAboutUsText());
+    }
+
+    private <T> void updateIfNotBlankAndNotEqual(T source , T destination, Consumer<T> update, String parameterName){
+        if (source != null && !source.equals(destination)){
+            if (source.getClass().equals(String.class) && ((String) source).isBlank()){
+                throw new IllegalArgumentException( String.format("%s cannot be blank", parameterName));
+            }
+            update.accept(source);
+            hasUpdate = Boolean.TRUE;
+        }
+    }
+
+    private <T> void updateIfNotEmptyAndNotEqual(JsonNullable<T> source , T destination, Consumer<T> update, String parameterName){
+        if (source != null) {
+            T internalSource = source.orElse(null);
+            if (internalSource != null && internalSource.getClass().equals(String.class) && ((String) internalSource).isBlank()) {
+                throw new IllegalArgumentException(String.format("%s cannot be blank", parameterName));
+            }
+            if(!Objects.equals(internalSource, destination)){
+                update.accept(internalSource);
+                hasUpdate = Boolean.TRUE;
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/alkemy/ong/util/JacksonConfig.java
+++ b/src/main/java/com/alkemy/ong/util/JacksonConfig.java
@@ -1,0 +1,20 @@
+package com.alkemy.ong.util;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    Jackson2ObjectMapperBuilder objectMapperBuilder() {
+        Jackson2ObjectMapperBuilder builder = new Jackson2ObjectMapperBuilder();
+        builder.serializationInclusion(JsonInclude.Include.ALWAYS)
+                .modulesToInstall(new JsonNullableModule());
+        builder.simpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        return builder;
+    }
+
+}

--- a/src/main/resources/locale/messages.properties
+++ b/src/main/resources/locale/messages.properties
@@ -1,0 +1,2 @@
+organization.notFound=cannot find any organization
+organization.blank=cannot be blank


### PR DESCRIPTION
Turco te paso la info de lo que hice, como hablamos ayer no hice un post porque pedía una actualización, terminé haciendo un patch porque me pareció lo que mejor funcionalidad le daba, ya que consideré que solo existe una organización.
En el patch tuve en consideración la actualización parcial de los datos, por lo que se puede enviar un campo, por ejemplo “name”, y no enviarse ningún otro para actualizar únicamente ese mismo. También validé el formato de los datos y los campos que no pueden ser null. Además, solo actualizo la fecha de actualización si se modificó algún campo. Espero que esté completo, cualquier cosa estoy a la escucha de posibles mejoras o bug que pudiera tener.
