### PR TITLE
Feature/83 testimonial pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,10 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.11.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-hateoas</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/alkemy/ong/assembler/TestimonialAssembler.java
+++ b/src/main/java/com/alkemy/ong/assembler/TestimonialAssembler.java
@@ -1,0 +1,35 @@
+package com.alkemy.ong.assembler;
+
+import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
+import org.springframework.stereotype.Component;
+import com.alkemy.ong.controller.TestimonialController;
+import com.alkemy.ong.dto.TestimonialResponse;
+import com.alkemy.ong.model.Testimonial;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class TestimonialAssembler extends RepresentationModelAssemblerSupport<Testimonial, TestimonialResponse> {
+
+    public TestimonialAssembler(){
+        super(TestimonialController.class, TestimonialResponse.class);
+    }
+
+    @Override
+    public TestimonialResponse toModel(Testimonial entity) {
+
+        TestimonialResponse testimonialDto = instantiateModel(entity);
+
+        testimonialDto.add(linkTo(
+            methodOn(TestimonialController.class)
+                    .findById(entity.getId()))
+            .withSelfRel());
+
+        testimonialDto.setName(entity.getName());
+        testimonialDto.setImage(entity.getImage());
+        testimonialDto.setContent(entity.getContent());
+
+        return testimonialDto;
+    }
+
+}

--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -1,16 +1,22 @@
 package com.alkemy.ong.controller;
 
+import com.alkemy.ong.assembler.TestimonialAssembler;
 import com.alkemy.ong.dto.TestimonialRequest;
+import com.alkemy.ong.dto.TestimonialResponse;
 import com.alkemy.ong.model.Testimonial;
 import com.alkemy.ong.security.SecurityConstant;
 import com.alkemy.ong.service.ITestimonialService;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import org.springframework.data.domain.Pageable;
 
 @RestController
 @RequestMapping("/testimonials")
@@ -18,6 +24,8 @@ import javax.validation.Valid;
 public class TestimonialController {
 
     private final ITestimonialService testimonialService;
+    private final TestimonialAssembler testimonialAssembler;
+    private final PagedResourcesAssembler<Testimonial> pagedResourcesAssembler;
 
     @DeleteMapping("/{id}")
     @PreAuthorize(SecurityConstant.ADMIN)
@@ -30,5 +38,23 @@ public class TestimonialController {
         return new ResponseEntity<>(testimonialService.addTestimonial(testimonialRequest), HttpStatus.CREATED);
 
     }
+
+    @GetMapping("/{id}")
+    @PreAuthorize(SecurityConstant.USER)
+    public ResponseEntity<?> findById(@Valid @PathVariable("id") Long id){
+        return new ResponseEntity<>(testimonialService.findById(id), HttpStatus.OK);
+    }
+
+    @GetMapping(params = "page")
+    @PreAuthorize(SecurityConstant.USER)
+    public ResponseEntity<PagedModel<TestimonialResponse>> findAllByName(Pageable pageable, @RequestParam("page") int page){
+        Page<Testimonial> testimonialEntities = testimonialService.readAllTestimonials(pageable, page);
+        PagedModel<TestimonialResponse> testimonialDto = pagedResourcesAssembler
+        .toModel(testimonialEntities, testimonialAssembler);
+
+return new ResponseEntity<>(testimonialDto, HttpStatus.OK);
+
+    }
+
 
 }

--- a/src/main/java/com/alkemy/ong/dto/TestimonialResponse.java
+++ b/src/main/java/com/alkemy/ong/dto/TestimonialResponse.java
@@ -1,0 +1,21 @@
+package com.alkemy.ong.dto;
+
+import com.alkemy.ong.util.ImageExtension;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
+import org.springframework.hateoas.RepresentationModel;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+public class TestimonialResponse extends RepresentationModel<TestimonialResponse> {
+    @NotBlank(message = "name cannot be blank")
+    private String name;
+    @URL(message = "image must be an URL")
+    @ImageExtension(message = "image extension not valid, must be JPG, JPEG or PNG")
+    private String image;
+    @NotBlank(message = "content cannot be blank")
+    private String content;
+}

--- a/src/main/java/com/alkemy/ong/mapper/TestimonialMapper.java
+++ b/src/main/java/com/alkemy/ong/mapper/TestimonialMapper.java
@@ -1,0 +1,19 @@
+package com.alkemy.ong.mapper;
+
+import com.alkemy.ong.dto.TestimonialResponse;
+import com.alkemy.ong.model.Testimonial;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestimonialMapper {
+
+    public TestimonialResponse testimonialModel2DTO(Testimonial model){
+        TestimonialResponse dto = new TestimonialResponse();
+        dto.setName(model.getName());
+        dto.setContent(model.getContent());
+        dto.setImage(model.getImage());
+
+        return dto;
+    }
+
+}

--- a/src/main/java/com/alkemy/ong/service/ITestimonialService.java
+++ b/src/main/java/com/alkemy/ong/service/ITestimonialService.java
@@ -1,13 +1,24 @@
 package com.alkemy.ong.service;
 
 import com.alkemy.ong.dto.TestimonialRequest;
+import com.alkemy.ong.dto.TestimonialResponse;
 import com.alkemy.ong.model.Testimonial;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 public interface ITestimonialService {
 
     ResponseEntity<?> delete(Long id);
 
     Testimonial addTestimonial(TestimonialRequest testimonialRequest);
+
+    public List<TestimonialResponse> findAllByName();
+
+    Page<Testimonial> readAllTestimonials(Pageable pageable, int page);
+
+    TestimonialResponse findById(Long id);
 
 }

--- a/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
@@ -1,24 +1,33 @@
 package com.alkemy.ong.service.impl;
 
 import com.alkemy.ong.dto.TestimonialRequest;
+import com.alkemy.ong.dto.TestimonialResponse;
 import com.alkemy.ong.exception.NotFoundException;
+import com.alkemy.ong.mapper.TestimonialMapper;
 import com.alkemy.ong.model.Testimonial;
 import com.alkemy.ong.repository.TestimonialRepository;
 import com.alkemy.ong.service.ITestimonialService;
 import lombok.AllArgsConstructor;
 import org.springframework.context.MessageSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
 public class TestimonialServiceImpl implements ITestimonialService {
 
     private final TestimonialRepository testimonialRepository;
+    private final TestimonialMapper testimonialMapper;
     private final MessageSource messageSource;
+    private static final int SIZE_DEFAULT = 10;
 
     @Override
     public ResponseEntity<?> delete(Long id) {
@@ -44,6 +53,35 @@ public class TestimonialServiceImpl implements ITestimonialService {
           }
 
           return testimonialRepository.save(testimonial);
+    }
+
+    @Override
+    public TestimonialResponse findById(Long id) throws NotFoundException{
+        String notFoundTestimonialsMessage = messageSource.getMessage("testimonial.notFound", null, Locale.US);
+        Testimonial testimonial = testimonialRepository.findById(id).orElseThrow(()-> new NotFoundException(notFoundTestimonialsMessage));
+        return testimonialMapper.testimonialModel2DTO(testimonial);
+    }
+
+    @Override
+    public List<TestimonialResponse> findAllByName() {
+        String testimonialListIsEmpty = messageSource.getMessage("testimonial.listEmpty", null, Locale.US);
+        List<TestimonialResponse> testimonialDto = testimonialRepository.findAll()
+                .stream()
+                .map(testimonial -> testimonialMapper.testimonialModel2DTO(testimonial))
+                .collect(Collectors.toList());
+        if(testimonialDto.isEmpty()){
+            throw new NotFoundException(testimonialListIsEmpty);
+        }
+        return testimonialDto;
+    }
+    @Override
+    public Page<Testimonial> readAllTestimonials(Pageable pageable , int page) {
+        String testimonialListPageNotFound = messageSource.getMessage("testimonial.pageNotFound", null, Locale.US);
+        pageable = (Pageable) PageRequest.of(page, SIZE_DEFAULT);
+        if (page > testimonialRepository.findAll(pageable).getTotalPages()) {
+            throw new NotFoundException(testimonialListPageNotFound);
+        }
+        return testimonialRepository.findAll((org.springframework.data.domain.Pageable) pageable);
     }
 
 }

--- a/src/main/resources/locale/messages.properties
+++ b/src/main/resources/locale/messages.properties
@@ -30,8 +30,7 @@ awss3.errorMessage.emptyFile=Image file cannot be null, please send an image
 
 updateUserMessageTemplate.failure=Not valid ID
 
-
-
+testimonial.pageNotFound=The page entered by url cannot be greater than the total number of pages
 
 api.blank=cannot be blank
 


### PR DESCRIPTION
Este ticket consistía en agregar paginación a testimonios como USER.
Para ello use la librería Spring Hateoas.

En primer lugar agregué 12 testimonios a la tabla.
Al querer consultarlas desde postman surge lo siguiente:

![image](https://user-images.githubusercontent.com/71157666/146391517-0f91b97d-a4f2-49c9-840b-f4a4ac61bed4.png)

Y al final de los 12 testimonios se pueden ver los links a la pagina previa, siguiente y última:

![image](https://user-images.githubusercontent.com/71157666/146391694-3648438a-ea27-4c7c-87be-97016d73167a.png)

Si le paso una pagina que no existe, me surge un 404:

![image](https://user-images.githubusercontent.com/71157666/146391940-028ffedf-a8ff-4856-977c-32c7e65c3310.png)
