### PR TITLE
Add pagination news

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,10 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.11.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-hateoas</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/alkemy/ong/assembler/NewsAssembler.java
+++ b/src/main/java/com/alkemy/ong/assembler/NewsAssembler.java
@@ -1,0 +1,38 @@
+package com.alkemy.ong.assembler;
+
+import com.alkemy.ong.controller.NewsController;
+import com.alkemy.ong.dto.NewsResponse;
+import com.alkemy.ong.model.News;
+import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class NewsAssembler extends RepresentationModelAssemblerSupport<News, NewsResponse> {
+
+    public NewsAssembler(){
+        super(NewsController.class, NewsResponse.class);
+    }
+
+    @Override
+    public NewsResponse toModel(News news){
+
+        NewsResponse newsResponse = instantiateModel(news);
+
+        newsResponse.add(linkTo(
+                    methodOn(NewsController.class)
+                            .findById(news.getId()))
+                            .withSelfRel());
+
+        newsResponse.setId(news.getId());
+        newsResponse.setName(news.getName());
+        newsResponse.setContent(news.getContent());
+        newsResponse.setImage(news.getImage());
+        newsResponse.setCategoryId(news.getCategory().getId());
+
+        return newsResponse;
+    }
+
+}

--- a/src/main/java/com/alkemy/ong/controller/NewsController.java
+++ b/src/main/java/com/alkemy/ong/controller/NewsController.java
@@ -1,13 +1,16 @@
-
-    
-   
 package com.alkemy.ong.controller;
 
+import com.alkemy.ong.assembler.NewsAssembler;
 import com.alkemy.ong.dto.NewsRequest;
 import com.alkemy.ong.dto.NewsResponse;
+import com.alkemy.ong.model.News;
 import com.alkemy.ong.security.SecurityConstant;
 import com.alkemy.ong.service.INewsService;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -21,6 +24,8 @@ import javax.validation.Valid;
 public class NewsController {
 
     private final INewsService newsService;
+    private final NewsAssembler newsAssembler;
+    private final PagedResourcesAssembler<News> pagedResourcesAssembler;
 
     @PutMapping(path = "{id}")
     @PreAuthorize(SecurityConstant.ADMIN)
@@ -51,5 +56,14 @@ public class NewsController {
 		
     }
 
+    @GetMapping(params = "page")
+    @PreAuthorize(SecurityConstant.USER)
+    public ResponseEntity<PagedModel<NewsResponse>> findAll(Pageable pageable, @RequestParam("page") int page){
+        Page<News> news = newsService.findAll(pageable, page);
+        PagedModel<NewsResponse> newsResponse = pagedResourcesAssembler
+                .toModel(news, newsAssembler);
+
+        return new ResponseEntity<>(newsResponse, HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/com/alkemy/ong/dto/NewsResponse.java
+++ b/src/main/java/com/alkemy/ong/dto/NewsResponse.java
@@ -1,13 +1,14 @@
 package com.alkemy.ong.dto;
 
 import lombok.*;
+import org.springframework.hateoas.RepresentationModel;
 
 @Getter
 @Setter
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-public class NewsResponse {
+public class NewsResponse extends RepresentationModel<NewsResponse> {
 
     private Long id;
     private String name;

--- a/src/main/java/com/alkemy/ong/mapper/NewsMapper.java
+++ b/src/main/java/com/alkemy/ong/mapper/NewsMapper.java
@@ -1,0 +1,21 @@
+package com.alkemy.ong.mapper;
+
+import com.alkemy.ong.dto.NewsResponse;
+import com.alkemy.ong.model.News;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NewsMapper {
+
+    public NewsResponse newsModelToDTO(News news) {
+        NewsResponse newsResponse = new NewsResponse();
+
+        newsResponse.setId(news.getId());
+        newsResponse.setName(news.getName());
+        newsResponse.setContent(news.getContent());
+        newsResponse.setImage(news.getImage());
+        newsResponse.setCategoryId(news.getCategory().getId());
+
+        return newsResponse;
+    }
+}

--- a/src/main/java/com/alkemy/ong/service/INewsService.java
+++ b/src/main/java/com/alkemy/ong/service/INewsService.java
@@ -1,11 +1,12 @@
 
 package com.alkemy.ong.service;
 
-import org.springframework.http.ResponseEntity;
-
 import com.alkemy.ong.dto.NewsRequest;
 import com.alkemy.ong.dto.NewsResponse;
 import com.alkemy.ong.model.News;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 
 public interface INewsService {
 
@@ -19,4 +20,5 @@ public interface INewsService {
 
     News findByIdReturnNews(Long id);
 
+    Page<News> findAll(Pageable pageable, int page);
 }

--- a/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
@@ -4,7 +4,6 @@ import com.alkemy.ong.dto.NewsRequest;
 import com.alkemy.ong.dto.NewsResponse;
 import com.alkemy.ong.exception.EmptyDataException;
 import com.alkemy.ong.exception.NotFoundException;
-import com.alkemy.ong.mapper.NewsMapper;
 import com.alkemy.ong.model.Category;
 import com.alkemy.ong.model.News;
 import com.alkemy.ong.repository.CategoryRepository;
@@ -140,5 +139,3 @@ public class NewsServiceImpl implements INewsService {
 
 
 }
-
-

--- a/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
@@ -1,10 +1,10 @@
-
-
 package com.alkemy.ong.service.impl;
 
 import com.alkemy.ong.dto.NewsRequest;
 import com.alkemy.ong.dto.NewsResponse;
+import com.alkemy.ong.exception.EmptyDataException;
 import com.alkemy.ong.exception.NotFoundException;
+import com.alkemy.ong.mapper.NewsMapper;
 import com.alkemy.ong.model.Category;
 import com.alkemy.ong.model.News;
 import com.alkemy.ong.repository.CategoryRepository;
@@ -14,6 +14,9 @@ import com.alkemy.ong.util.UpdateFields;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.MessageSource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -29,7 +32,6 @@ public class NewsServiceImpl implements INewsService {
     private final NewsRepository newsRepository;
     private final MessageSource messageSource;
     private final UpdateFields updateFields;
-
 
     public NewsRequest createNews(NewsRequest newsDto){
         News entity = newsDTO2Entity(newsDto);
@@ -118,6 +120,25 @@ public class NewsServiceImpl implements INewsService {
         String newsNotFound = messageSource.getMessage("news.notFound", null, Locale.US);
         return newsRepository.findById(id).orElseThrow(() -> new NotFoundException(newsNotFound));
     }
+
+    @Override
+    public Page<News> findAll(Pageable pageable, int page){
+        String moreThanTotalPageError = messageSource.getMessage("news.moreThanTotalPage", null, Locale.US);
+        String newsEmptyList = messageSource.getMessage("news.emptyList", null, Locale.US);
+        final int size = 10;
+        pageable = PageRequest.of(page, size);
+
+        if(newsRepository.findAll().isEmpty()){
+            throw new EmptyDataException(newsEmptyList);
+        }
+        if (page > newsRepository.findAll(pageable).getTotalPages()){
+            throw new NotFoundException(moreThanTotalPageError);
+        }
+        
+        return newsRepository.findAll(pageable);
+    }
+
+
 }
 
 

--- a/src/main/resources/locale/messages.properties
+++ b/src/main/resources/locale/messages.properties
@@ -10,7 +10,8 @@ activity.notFound=cannot find any activity
 
 news.notFound=cannot find any news
 news.isDeleted=the news has been removed
-
+news.emptyList=News list is empty
+news.moreThanTotalPage=The page number cannot be greater than the total number of pages
 welcomeMessageTemplate.failure=Welcome Email creating failure
 welcomeMessageTemplate.emailSubject=Welcome Email
 


### PR DESCRIPTION
Turco Aquí agrego la paginación en novedades.
Primero lo hice solo con paginación, pero después vi que usaron Spring Hateoas y decidí hacerlo de la misma manera, ya que me pareció mas completa la información que aporta en la respuesta, como ser el "Self" para indicar en la pagina donde se encuentra actualmente, y el total de elementos, etc.

Caso de éxito primera pagina "0":
![endpointNewsExito1](https://user-images.githubusercontent.com/11466425/146437025-6513d7bb-56b9-4c8b-9b94-be3eb6d554c0.png)
Caso de éxito 2da parte:
![endpointNewsExito2](https://user-images.githubusercontent.com/11466425/146437110-b6b242c3-0d24-4418-8e35-6cbe0369359e.png)
Caso de éxito pagina siguiente "1":
![exitoPaginaSiguiente](https://user-images.githubusercontent.com/11466425/146437211-5c8656f9-6176-4a64-84a0-7ae7352b6327.png)


Caso de error indice negativo/ pagina negativa:

![endpointErrorMenorACero](https://user-images.githubusercontent.com/11466425/146437306-b441b2d1-66b3-4119-bdd0-14bb07b7db12.png)

Caso de error pagina mayor al limite:
![endpointErrorMayorAlLimite](https://user-images.githubusercontent.com/11466425/146437392-1dde522a-2112-4015-8c82-4e25ee754349.png)



