### PR TITLE
Feature/89 add documentation to authentication

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/docs/AuthenticationConstantDocs.java
+++ b/src/main/java/com/alkemy/ong/controller/docs/AuthenticationConstantDocs.java
@@ -1,0 +1,36 @@
+package com.alkemy.ong.controller.docs;
+
+public interface AuthenticationConstantDocs {
+
+	String AUTHENTICATION = "Testimonial Docs";
+	
+	String AUTHENTICATION_SINGUP = "Register a new user";
+	String AUTHENTICATION_SINGUP_NOTE = "This endpoint is used to register a new user, by default user permissions are assigned";
+
+	String AUTHENTICATION_SINGIN = "Login with a registered user";
+	String AUTHENTICATION_SINGIN_NOTE = "This endpoint will be used to log users already registered, returns the token";
+
+	String AUTHENTICATION_ME = "Returns user information from token";
+	String AUTHENTICATION_ME_NOTE = "This endpoint returns the ID, first name, last name, email and photo of the user from token";
+
+	String AUTHENTICATION_TOKEN = "User's token, contains the user's id, roles, email and the expiration date of the token";
+	String AUTHENTICATION_EMAIL = "User email, cannot be empty";
+	String AUTHENTICATION_PASS = "User password, cannot be empty";
+
+	String AUTHENTICATION_ID = "Unique user ID";
+	String AUTHENTICATION_FIRSTNAME = "User's first name";
+	String AUTHENTICATION_LASTNAME = "User's last name";
+	String AUTHENTICATION_PHOTO = "User's photo";
+
+	String AUTHENTICATION_USERREQUEST_PASS = "User password, cannot be empty and its minimum length is 5 characters";
+	String AUTHENTICATION_USERREQUEST_FIRSTNAME = "User's first name, cannot be empty";
+	String AUTHENTICATION_USERREQUEST_LASTNAME = "User's last name, cannot be empty";
+	String AUTHENTICATION_USERREQUEST_EMAIL = "User's email, cannot be empty, It must also have the email format example@example.com";
+	String AUTHENTICATION_USERREQUEST_PHOTO = "User's photo, can be null";
+
+	String AUTHENTICATION_SINGUP_PARAM = "User information for registration, sent through the body";
+	String AUTHENTICATION_SINGIN_PARAM = "User information for the login, sent through the body";
+	String AUTHENTICATION_ME_PARAM = "User token sent in the header";
+
+
+}

--- a/src/main/java/com/alkemy/ong/dto/UserAuthenticatedResponseDto.java
+++ b/src/main/java/com/alkemy/ong/dto/UserAuthenticatedResponseDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 @Getter
@@ -8,9 +10,15 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class UserAuthenticatedResponseDto {
+
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_ID)
     private Long id;
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_FIRSTNAME)
     private String firstName;
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_LASTNAME)
     private String lastName;
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_EMAIL)
     private String email;
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_PHOTO)
     private String photo;
 }

--- a/src/main/java/com/alkemy/ong/dto/UserAuthenticatedResponseDto.java
+++ b/src/main/java/com/alkemy/ong/dto/UserAuthenticatedResponseDto.java
@@ -1,6 +1,6 @@
 package com.alkemy.ong.dto;
 
-import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
+import com.alkemy.ong.util.docs.AuthenticationConstantDocs;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 

--- a/src/main/java/com/alkemy/ong/dto/UserRequest.java
+++ b/src/main/java/com/alkemy/ong/dto/UserRequest.java
@@ -1,7 +1,6 @@
 package com.alkemy.ong.dto;
 
-import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
-import io.swagger.annotations.ApiModel;
+import com.alkemy.ong.util.docs.AuthenticationConstantDocs;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/alkemy/ong/dto/UserRequest.java
+++ b/src/main/java/com/alkemy/ong/dto/UserRequest.java
@@ -1,5 +1,8 @@
 package com.alkemy.ong.dto;
 
+import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,20 +16,25 @@ import javax.validation.constraints.*;
 @AllArgsConstructor
 public class UserRequest {
 
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_USERREQUEST_FIRSTNAME)
     @NotBlank(message = "Name is necessary.")
     private String firstName;
 
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_USERREQUEST_LASTNAME)
     @NotBlank(message = "Last name is necessary.")
     private String lastName;
 
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_USERREQUEST_EMAIL)
     @NotBlank(message = "Email is necessary.")
     @Email(message = "Email should be valid.", regexp = "[A-Za-z0-9._%-+]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}")
     private String email;
 
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_USERREQUEST_PASS)
     @NotBlank(message = "Password is necessary.")
     @Length(min = 5, message = "Password must be min 5  characters.")
     private String password;
 
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_USERREQUEST_PHOTO)
     @Nullable
     private String photo;
 

--- a/src/main/java/com/alkemy/ong/security/controller/AuthenticationController.java
+++ b/src/main/java/com/alkemy/ong/security/controller/AuthenticationController.java
@@ -1,11 +1,16 @@
 package com.alkemy.ong.security.controller;
 
+import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
+import com.alkemy.ong.controller.docs.TestimonialConstantDocs;
+import com.alkemy.ong.dto.UserAuthenticatedResponseDto;
 import com.alkemy.ong.dto.UserRequest;
 import com.alkemy.ong.exception.EmailExistException;
+import com.alkemy.ong.security.dto.LoggedUserDto;
 import com.alkemy.ong.security.dto.LoginDto;
 import com.alkemy.ong.security.service.CustomUserDetailsService;
 import com.alkemy.ong.security.service.IAuthenticationService;
 import com.alkemy.ong.service.IUserService;
+import io.swagger.annotations.*;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,24 +21,36 @@ import javax.validation.Valid;
 @RestController
 @RequestMapping("/auth")
 @AllArgsConstructor
+@Api(value = AuthenticationConstantDocs.AUTHENTICATION)
 public class AuthenticationController {
 
     private final IAuthenticationService authenticationService;
     private final IUserService userService;
     private final CustomUserDetailsService customUserDetailsService;
 
+    @ApiOperation(value = AuthenticationConstantDocs.AUTHENTICATION_SINGUP,
+            notes = AuthenticationConstantDocs.AUTHENTICATION_SINGUP_NOTE,
+            response = LoggedUserDto.class)
     @PostMapping("/register")
-    public ResponseEntity<?> signUp(@Valid @RequestBody UserRequest user) throws EmailExistException{
+    public ResponseEntity<?> signUp(@ApiParam(value = AuthenticationConstantDocs.AUTHENTICATION_SINGUP_PARAM, required = true)
+                                        @Valid @RequestBody UserRequest user) throws EmailExistException{
         return new ResponseEntity<>(userService.createUser(user), HttpStatus.CREATED);
     }
-
+    @ApiOperation(value = AuthenticationConstantDocs.AUTHENTICATION_SINGIN,
+            notes = AuthenticationConstantDocs.AUTHENTICATION_SINGIN_NOTE,
+            response = LoggedUserDto.class)
     @PostMapping("/login")
-    public ResponseEntity<?> signIn(@Valid @RequestBody LoginDto user){
+    public ResponseEntity<?> signIn(@ApiParam(value = AuthenticationConstantDocs.AUTHENTICATION_SINGIN_PARAM, required = true)
+                                        @Valid @RequestBody LoginDto user){
         return new ResponseEntity<>(authenticationService.signInAndReturnJWT(user), HttpStatus.OK);
     }
 
+    @ApiOperation(value = AuthenticationConstantDocs.AUTHENTICATION_ME,
+            notes = AuthenticationConstantDocs.AUTHENTICATION_ME_NOTE,
+            response = UserAuthenticatedResponseDto.class)
     @GetMapping("/me")
-    public ResponseEntity<?> getAuthenticatedUserDetails(@RequestHeader(value = "Authorization") String authorizationHeader){
+    public ResponseEntity<?> getAuthenticatedUserDetails(@ApiParam(value = AuthenticationConstantDocs.AUTHENTICATION_ME_PARAM, required = true)
+                                                             @RequestHeader(value = "Authorization") String authorizationHeader){
         return new ResponseEntity<>(customUserDetailsService.getUserDetails(authorizationHeader),HttpStatus.OK);
     }
 

--- a/src/main/java/com/alkemy/ong/security/controller/AuthenticationController.java
+++ b/src/main/java/com/alkemy/ong/security/controller/AuthenticationController.java
@@ -1,7 +1,6 @@
 package com.alkemy.ong.security.controller;
 
 import com.alkemy.ong.util.docs.AuthenticationConstantDocs;
-import com.alkemy.ong.controller.docs.TestimonialConstantDocs;
 import com.alkemy.ong.dto.UserAuthenticatedResponseDto;
 import com.alkemy.ong.dto.UserRequest;
 import com.alkemy.ong.exception.EmailExistException;

--- a/src/main/java/com/alkemy/ong/security/controller/AuthenticationController.java
+++ b/src/main/java/com/alkemy/ong/security/controller/AuthenticationController.java
@@ -1,6 +1,6 @@
 package com.alkemy.ong.security.controller;
 
-import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
+import com.alkemy.ong.util.docs.AuthenticationConstantDocs;
 import com.alkemy.ong.controller.docs.TestimonialConstantDocs;
 import com.alkemy.ong.dto.UserAuthenticatedResponseDto;
 import com.alkemy.ong.dto.UserRequest;

--- a/src/main/java/com/alkemy/ong/security/dto/LoggedUserDto.java
+++ b/src/main/java/com/alkemy/ong/security/dto/LoggedUserDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.security.dto;
 
+import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +15,7 @@ import lombok.ToString;
 @ToString
 public class LoggedUserDto {
 
+	@ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_TOKEN)
 	private String token;
 	
 }

--- a/src/main/java/com/alkemy/ong/security/dto/LoggedUserDto.java
+++ b/src/main/java/com/alkemy/ong/security/dto/LoggedUserDto.java
@@ -1,6 +1,6 @@
 package com.alkemy.ong.security.dto;
 
-import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
+import com.alkemy.ong.util.docs.AuthenticationConstantDocs;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/alkemy/ong/security/dto/LoginDto.java
+++ b/src/main/java/com/alkemy/ong/security/dto/LoginDto.java
@@ -3,6 +3,8 @@ package com.alkemy.ong.security.dto;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,9 +16,11 @@ import lombok.Setter;
 @Setter
 public class LoginDto {
 
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_EMAIL)
     @NotBlank
     @NotNull(message= "You must enter your email to be able to login")
     private String email;
+    @ApiModelProperty(value = AuthenticationConstantDocs.AUTHENTICATION_PASS)
     @NotBlank
     @NotNull(message= "You must enter your password to be able to login")
     private String password;

--- a/src/main/java/com/alkemy/ong/security/dto/LoginDto.java
+++ b/src/main/java/com/alkemy/ong/security/dto/LoginDto.java
@@ -3,7 +3,7 @@ package com.alkemy.ong.security.dto;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-import com.alkemy.ong.controller.docs.AuthenticationConstantDocs;
+import com.alkemy.ong.util.docs.AuthenticationConstantDocs;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/alkemy/ong/util/docs/AuthenticationConstantDocs.java
+++ b/src/main/java/com/alkemy/ong/util/docs/AuthenticationConstantDocs.java
@@ -1,4 +1,4 @@
-package com.alkemy.ong.controller.docs;
+package com.alkemy.ong.util.docs;
 
 public interface AuthenticationConstantDocs {
 


### PR DESCRIPTION
Turco te dejo mi PR me tocaba agregar documentación a la parte de autenticación. Reutilice la idea de Ale de utilizar una interface para tener escritos los mensajes en un solo lugar.
![Documentation4](https://user-images.githubusercontent.com/84400475/147177372-8ad302f5-bc95-4f19-a73d-eef3039608df.png)
![Documentation5](https://user-images.githubusercontent.com/84400475/147177374-3774db60-0fc1-4fb3-9c63-79c8d574c1e9.png)
![Documentation6](https://user-images.githubusercontent.com/84400475/147177376-7abda987-9747-4120-9c5a-5b060edb7f15.png)
![Documentation1](https://user-images.githubusercontent.com/84400475/147177377-afa859d3-2a78-47ab-81b8-6ab13ddd6ebf.png)
![Documentation2](https://user-images.githubusercontent.com/84400475/147177379-c1fced1a-a470-4983-b222-1b9839eecab3.png)
![Documentation3](https://user-images.githubusercontent.com/84400475/147177380-2bb24f8d-b97c-4b79-92f4-43d9a8951237.png)
 